### PR TITLE
feat(scope): add support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ var got = require('got');
 var registryUrl = require('registry-url');
 
 module.exports = function (name, version, cb) {
+	var url = registryUrl(name.split('/')[0]);
+
 	if (typeof version !== 'string') {
 		cb = version;
 		version = '';
 	}
 
-	got(registryUrl + encodeURIComponent(name) + '/' + version, function (err, data) {
+	got(url + encodeURIComponent(name) + '/' + version, function (err, data) {
 		if (err && err.code === 404) {
 			cb(new Error('Package or version doesn\'t exist'));
 			return;


### PR DESCRIPTION
Add support for [npm scopes](https://docs.npmjs.com/misc/scope) by using
a more up-to-date version of `registry-url` that has can retrieve the
registry URL associated with a scope.

Closes #2 