### PR TITLE
Fixed single field retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,15 +27,14 @@ module.exports = function (name, version) {
 };
 
 module.exports.field = function (name, field) {
-	var url = registryUrl(name.split('/')[0]) +
-		'-/by-field/?key=%22' + name + '%22&field=' + field;
+	var url = registryUrl(name.split('/')[0]) + name + '/latest';
 
 	return get(url)
 		.then(function (res) {
-			if (Object.keys(res).length === 0) {
+			if (res[field] === undefined) {
 				throw Error('Field `' + field + '` doesn\'t exist');
 			}
 
-			return res[name][field];
+			return res[field];
 		});
 };

--- a/test.js
+++ b/test.js
@@ -19,9 +19,9 @@ test('get package.json main entry when no version is specified', async t => {
 	t.is(json._id, 'pageres');
 });
 
-// test('get a single field', async t => {
-// 	const res = await fn.field('pageres', 'description');
+test('get a single field', async t => {
+	const res = await fn.field('pageres', 'description');
 
-// 	t.true(res === 'string');
-// 	t.regexTest(/screenshots/, res);
-// });
+	t.true(typeof res === 'string');
+	t.regexTest(/screenshots/, res);
+});


### PR DESCRIPTION
Because the `by-field` endpoint doesn't work anymore, this might be a temporary workaround. Instead of fetching the entire history of all the versions, it just retrieves the `latest` version which is a lot smaller and then returns the field (if it exists).

If you don't like it, just close it :). Just wanted to share my temporary fix.