### PR TITLE
Improve performance and add support for versions like ~1.2.3 and ^1.2.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@ var registryUrl = require('registry-url');
 var rc = require('rc');
 
 module.exports = function (name, version) {
+	var isScoped = name.indexOf('/') > -1;
 	var scope = name.split('/')[0];
 	var url = registryUrl(scope) +
-		encodeURIComponent(name).replace(/^%40/, '@');
+		encodeURIComponent(name).replace(/^%40/, '@') +
+		(!isScoped && version ? '/' + version : '');
 	var npmrc = rc('npm');
 	var token = npmrc[scope + ':_authToken'] || npmrc['//registry.npmjs.org/:_authToken'];
 	var headers = {};
@@ -26,9 +28,9 @@ module.exports = function (name, version) {
 		.then(function (res) {
 			var data = res.body;
 
-			if (version === 'latest') {
+			if (isScoped && version === 'latest') {
 				data = data.versions[data['dist-tags'].latest];
-			} else if (version) {
+			} else if (isScoped && version) {
 				data = data.versions[version];
 
 				if (!data) {

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,16 @@ packageJson('@company/package', 'latest').then(json => {
 ### packageJson(name, [version])
 
 You can optionally specify a version (e.g. `1.0.0`) or `latest`.  
-If you don't specify a version you'll get the [main entry](http://registry.npmjs.org/pageres/) containing all versions.
+If you don't specify a version you'll get the [main entry](https://registry.npmjs.org/pageres/) containing all versions.
 
+If the package is not scoped, the version can be in the form of:
+
+* `1` - get the latest `1.x.x`
+* `1.2` - get the latest `1.2.x`
+* `^1.2.3` - get the latest `1.x.x` but at least `1.2.3`
+* `~1.2.3` - get the latest `1.2.x` but at least `1.2.3`
+
+(Currently only full version numbers are supported for scoped packages.)
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -17,6 +17,41 @@ test('specific version', async t => {
 	t.is(json.version, '0.1.0');
 });
 
+test('incomplete version x', async t => {
+	const json = await fn('pageres', '0');
+	t.is(json.version.substr(0,2), '0.');
+});
+
+test('incomplete version x.y', async t => {
+	const json = await fn('pageres', '0.1');
+	t.is(json.version.substr(0,4), '0.1.');
+});
+
+test('caret version', async t => {
+	const json = await fn('got', '^5.0.0');
+	t.is(json.version.substr(0,2), '5.');
+});
+
+test('tilde version', async t => {
+	const json = await fn('got', '~5.0.0');
+	t.is(json.version.substr(0,4), '5.0.');
+});
+
+test('wildcard version *', async t => {
+	const json = await fn('got', '*');
+	t.is(json.version.split('.')[0] > 0, true);
+});
+
+test('wildcard version x.*', async t => {
+	const json = await fn('got', '5.*');
+	t.is(json.version.substr(0,2), '5.');
+});
+
+test('wildcard version x.y.*', async t => {
+	const json = await fn('got', '5.0.*');
+	t.is(json.version.substr(0,4), '5.0.');
+});
+
 test('scoped - full', async t => {
 	const json = await fn('@sindresorhus/df');
 	t.is(json.name, '@sindresorhus/df');

--- a/test.js
+++ b/test.js
@@ -52,6 +52,15 @@ test('wildcard version x.y.*', async t => {
 	t.is(json.version.substr(0,4), '5.0.');
 });
 
+test('single version data the same as in main entry with all versions', async t => {
+	const full1 = await fn('got');
+	const single1 = await fn('got', '3.3.1');
+	t.same(full1.versions['3.3.1'], single1);
+	const full2 = await fn('express');
+	const single2 = await fn('express', '4.10.2');
+	t.same(full2.versions['4.10.2'], single2);
+});
+
 test('scoped - full', async t => {
 	const json = await fn('@sindresorhus/df');
 	t.is(json.name, '@sindresorhus/df');


### PR DESCRIPTION
It improves performance by downloading only the data of the version that is requested, instead of downloading data about every published version in the history of the package only to throw most of it away, as was the case before.

The difference is significant, for some modules like express it is 2kB vs 500kB, see:

time curl -s https://registry.npmjs.org/express | wc -c
time curl -s https://registry.npmjs.org/express/4.0.0 | wc -c

This is not only a waste of time and bandwidth from the perspective of the module user but also a significant waste of resources of the npm registry.

This PR also adds support for version numbers like:

* `1` - get the latest `1.x.x`
* `1.2` - get the latest `1.2.x`
* `^1.2.3` - get the latest `1.x.x` but at least `1.2.3`
* `~1.2.3` - get the latest `1.2.x` but at least `1.2.3`

so this module could be used to test most versions found in package.json dependencies.

It adds tests for the new version formats and makes sure that the data returned after this pull request is still the same as before.

It adds examples to the readme.