### PR TITLE
Add support for ^1.2.3 and ~1.2.3 versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (name, version) {
 			if (version === 'latest') {
 				data = data.versions[data['dist-tags'].latest];
 			} else if (version) {
-				if (!semver.valid(version)) {
+				if (!data.versions[version]) {
 					var versions = Object.keys(data.versions)
 						.filter(function (v) {
 							return semver.satisfies(v, version);

--- a/index.js
+++ b/index.js
@@ -31,22 +31,10 @@ module.exports = function (name, version) {
 				data = data.versions[data['dist-tags'].latest];
 			} else if (version) {
 				if (!data.versions[version]) {
-					var versions = Object.keys(data.versions)
-						.filter(function (v) {
-							return semver.satisfies(v, version);
-						});
-					if (versions.length === 0) {
+					var versions = Object.keys(data.versions);
+					version = semver.maxSatisfying(versions, version);
+					if (!version) {
 						throw new Error('Version doesn\'t exist');
-					} else {
-						version = versions.sort(function (a, b) {
-							if (semver.gt(a, b)) {
-								return -1;
-							}
-							if (semver.lt(a, b)) {
-								return 1;
-							}
-							return 0;
-						})[0];
 					}
 				}
 				data = data.versions[version];

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "got": "^5.0.0",
     "rc": "^1.1.2",
-    "registry-url": "^3.0.3"
+    "registry-url": "^3.0.3",
+    "semver": "^5.1.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -35,14 +35,12 @@ packageJson('@company/package', 'latest').then(json => {
 You can optionally specify a version (e.g. `1.0.0`) or `latest`.  
 If you don't specify a version you'll get the [main entry](http://registry.npmjs.org/pageres/) containing all versions.
 
-The version can also be in the form that is often used in the package.json files:
+The version can also be in any format supported by the [semver](https://www.npmjs.com/package/semver) module. For example:
 
 * `1` - get the latest `1.x.x`
 * `1.2` - get the latest `1.2.x`
 * `^1.2.3` - get the latest `1.x.x` but at least `1.2.3`
 * `~1.2.3` - get the latest `1.2.x` but at least `1.2.3`
-
-It works for both scoped and unscoped packages.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,14 @@ packageJson('@company/package', 'latest').then(json => {
 You can optionally specify a version (e.g. `1.0.0`) or `latest`.  
 If you don't specify a version you'll get the [main entry](http://registry.npmjs.org/pageres/) containing all versions.
 
+The version can also be in the form that is often used in the package.json files:
+
+* `1` - get the latest `1.x.x`
+* `1.2` - get the latest `1.2.x`
+* `^1.2.3` - get the latest `1.x.x` but at least `1.2.3`
+* `~1.2.3` - get the latest `1.2.x` but at least `1.2.3`
+
+It works for both scoped and unscoped packages.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -22,54 +22,6 @@ test('incomplete version x', async t => {
 	t.is(json.version.substr(0,2), '0.');
 });
 
-test('incomplete version x.y', async t => {
-	const json = await fn('pageres', '0.1');
-	t.is(json.version.substr(0,4), '0.1.');
-});
-
-test('caret version', async t => {
-	const json = await fn('got', '^5.0.0');
-	t.is(json.version.substr(0,2), '5.');
-});
-
-test('tilde version', async t => {
-	const json = await fn('got', '~5.0.0');
-	t.is(json.version.substr(0,4), '5.0.');
-});
-
-test('wildcard version *', async t => {
-	const json = await fn('got', '*');
-	t.is(json.version.split('.')[0] > 0, true);
-});
-
-test('wildcard version x.*', async t => {
-	const json = await fn('got', '5.*');
-	t.is(json.version.substr(0,2), '5.');
-});
-
-test('wildcard version x.y.*', async t => {
-	const json = await fn('got', '5.0.*');
-	t.is(json.version.substr(0,4), '5.0.');
-});
-
-test('data the same as in main entry with all versions for got', async t => {
-	t.plan(1);
-	const full = fn('got');
-	const single = fn('got', '3.3.1');
-	Promise.all([full, single]).then(function (m) {
-		t.same(m[0].versions['3.3.1'], m[1]);
-	});
-});
-
-test('data the same as in main entry with all versions for express', async t => {
-	t.plan(1);
-	const full = fn('express');
-	const single = fn('express', '4.10.2');
-	Promise.all([full, single]).then(function (m) {
-		t.same(m[0].versions['4.10.2'], m[1]);
-	});
-});
-
 test('scoped - full', async t => {
 	const json = await fn('@sindresorhus/df');
 	t.is(json.name, '@sindresorhus/df');
@@ -84,41 +36,6 @@ test('scoped - latest version', async t => {
 test('scoped - specific version', async t => {
 	const json = await fn('@sindresorhus/df', '1.0.1');
 	t.is(json.version, '1.0.1');
-});
-
-test('scoped - incomplete version x', async t => {
-	const json = await fn('@sindresorhus/df', '1');
-	t.is(json.version.substr(0,2), '1.');
-});
-
-test('scoped - incomplete version x.y', async t => {
-	const json = await fn('@sindresorhus/df', '1.0');
-	t.is(json.version.substr(0,4), '1.0.');
-});
-
-test('scoped - caret version', async t => {
-	const json = await fn('@sindresorhus/df', '^1.0.0');
-	t.is(json.version.substr(0,2), '1.');
-});
-
-test('scoped - tilde version', async t => {
-	const json = await fn('@sindresorhus/df', '~1.0.0');
-	t.is(json.version.substr(0,4), '1.0.');
-});
-
-test('scoped - wildcard version *', async t => {
-	const json = await fn('@sindresorhus/df', '*');
-	t.is(json.version.split('.')[0] > 0, true);
-});
-
-test('scoped - wildcard version x.*', async t => {
-	const json = await fn('@sindresorhus/df', '1.*');
-	t.is(json.version.substr(0,2), '1.');
-});
-
-test('scoped - wildcard version x.y.*', async t => {
-	const json = await fn('@sindresorhus/df', '1.0.*');
-	t.is(json.version.substr(0,4), '1.0.');
 });
 
 test('reject when version doesn\'t exist', async t => {

--- a/test.js
+++ b/test.js
@@ -53,15 +53,21 @@ test('wildcard version x.y.*', async t => {
 });
 
 test('data the same as in main entry with all versions for got', async t => {
-	const full1 = await fn('got');
-	const single1 = await fn('got', '3.3.1');
-	t.same(full1.versions['3.3.1'], single1);
+	t.plan(1);
+	const full = fn('got');
+	const single = fn('got', '3.3.1');
+	Promise.all([full, single]).then(function (m) {
+		t.same(m[0].versions['3.3.1'], m[1]);
+	});
 });
 
 test('data the same as in main entry with all versions for express', async t => {
-	const full2 = await fn('express');
-	const single2 = await fn('express', '4.10.2');
-	t.same(full2.versions['4.10.2'], single2);
+	t.plan(1);
+	const full = fn('express');
+	const single = fn('express', '4.10.2');
+	Promise.all([full, single]).then(function (m) {
+		t.same(m[0].versions['4.10.2'], m[1]);
+	});
 });
 
 test('scoped - full', async t => {

--- a/test.js
+++ b/test.js
@@ -17,6 +17,53 @@ test('specific version', async t => {
 	t.is(json.version, '0.1.0');
 });
 
+test('incomplete version x', async t => {
+	const json = await fn('pageres', '0');
+	t.is(json.version.substr(0,2), '0.');
+});
+
+test('incomplete version x.y', async t => {
+	const json = await fn('pageres', '0.1');
+	t.is(json.version.substr(0,4), '0.1.');
+});
+
+test('caret version', async t => {
+	const json = await fn('got', '^5.0.0');
+	t.is(json.version.substr(0,2), '5.');
+});
+
+test('tilde version', async t => {
+	const json = await fn('got', '~5.0.0');
+	t.is(json.version.substr(0,4), '5.0.');
+});
+
+test('wildcard version *', async t => {
+	const json = await fn('got', '*');
+	t.is(json.version.split('.')[0] > 0, true);
+});
+
+test('wildcard version x.*', async t => {
+	const json = await fn('got', '5.*');
+	t.is(json.version.substr(0,2), '5.');
+});
+
+test('wildcard version x.y.*', async t => {
+	const json = await fn('got', '5.0.*');
+	t.is(json.version.substr(0,4), '5.0.');
+});
+
+test('data the same as in main entry with all versions for got', async t => {
+	const full1 = await fn('got');
+	const single1 = await fn('got', '3.3.1');
+	t.same(full1.versions['3.3.1'], single1);
+});
+
+test('data the same as in main entry with all versions for express', async t => {
+	const full2 = await fn('express');
+	const single2 = await fn('express', '4.10.2');
+	t.same(full2.versions['4.10.2'], single2);
+});
+
 test('scoped - full', async t => {
 	const json = await fn('@sindresorhus/df');
 	t.is(json.name, '@sindresorhus/df');
@@ -31,6 +78,41 @@ test('scoped - latest version', async t => {
 test('scoped - specific version', async t => {
 	const json = await fn('@sindresorhus/df', '1.0.1');
 	t.is(json.version, '1.0.1');
+});
+
+test('scoped - incomplete version x', async t => {
+	const json = await fn('@sindresorhus/df', '1');
+	t.is(json.version.substr(0,2), '1.');
+});
+
+test('scoped - incomplete version x.y', async t => {
+	const json = await fn('@sindresorhus/df', '1.0');
+	t.is(json.version.substr(0,4), '1.0.');
+});
+
+test('scoped - caret version', async t => {
+	const json = await fn('@sindresorhus/df', '^1.0.0');
+	t.is(json.version.substr(0,2), '1.');
+});
+
+test('scoped - tilde version', async t => {
+	const json = await fn('@sindresorhus/df', '~1.0.0');
+	t.is(json.version.substr(0,4), '1.0.');
+});
+
+test('scoped - wildcard version *', async t => {
+	const json = await fn('@sindresorhus/df', '*');
+	t.is(json.version.split('.')[0] > 0, true);
+});
+
+test('scoped - wildcard version x.*', async t => {
+	const json = await fn('@sindresorhus/df', '1.*');
+	t.is(json.version.substr(0,2), '1.');
+});
+
+test('scoped - wildcard version x.y.*', async t => {
+	const json = await fn('@sindresorhus/df', '1.0.*');
+	t.is(json.version.substr(0,4), '1.0.');
 });
 
 test('reject when version doesn\'t exist', async t => {


### PR DESCRIPTION
It adds support for wildcard, caret and tilde versions for both scoped and unscoped packages so this module could be used to test most versions found in `package.json` dependencies:

* `1` - get the latest `1.x.x`
* `1.2` - get the latest `1.2.x`
* `^1.2.3` - get the latest `1.x.x` but at least `1.2.3`
* `~1.2.3` - get the latest `1.2.x` but at least `1.2.3`

But it keeps downloading the entire data for all versions from the npm registry - see comments to PR #16 

It adds tests for the new version formats and makes sure that the data returned after this pull request is still the same as before.

It adds examples to the readme.