### PR TITLE
more descriptive error message for non-existent packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function (name, version) {
 		})
 		.catch(function (err) {
 			if (err.statusCode === 404) {
-				throw new Error('Package doesn\'t exist');
+				throw new Error('Package `' + name + '` doesn\'t exist');
 			}
 
 			throw err;

--- a/test.js
+++ b/test.js
@@ -41,3 +41,7 @@ test('scoped - specific version', async t => {
 test('reject when version doesn\'t exist', async t => {
 	t.throws(fn('hapi', '6.6.6'), 'Version doesn\'t exist');
 });
+
+test('reject when package doesn\'t exist', async t => {
+	t.throws(fn('nnnope'), 'Package `nnnope` doesn\'t exist');
+});


### PR DESCRIPTION
I'm using `latest-version` with `Promise.all` to request npm packages and some of them can be unavailable on npm, so current implementation show just that `package doesn't exist` but i requested bunch of packages, so it unclear which one doesn't exist. This small fix will clarify name of non-existing package.