### PR TITLE
Call private registry with basic auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = function (name, version) {
 		encodeURIComponent(name).replace(/^%40/, '@');
 	var npmrc = rc('npm');
 	var token = npmrc[scope + ':_authToken'] || npmrc['//registry.npmjs.org/:_authToken'];
-	var headers = {}, auth;
+	var headers = {};
+	var auth;
 
 	if (token) {
 		if (process.env.NPM_TOKEN) {
@@ -18,8 +19,8 @@ module.exports = function (name, version) {
 		}
 
 		headers.authorization = 'Bearer ' + token;
-	} else if(npmrc._auth) {
-		auth = new Buffer(npmrc._auth, 'base64').toString('utf-8');
+	} else if (npmrc._auth) {
+		auth = new Buffer(npmrc._auth, 'base64').toString('utf8');
 	}
 
 	return got(url, {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (name, version) {
 		encodeURIComponent(name).replace(/^%40/, '@');
 	var npmrc = rc('npm');
 	var token = npmrc[scope + ':_authToken'] || npmrc['//registry.npmjs.org/:_authToken'];
-	var headers = {};
+	var headers = {}, auth;
 
 	if (token) {
 		if (process.env.NPM_TOKEN) {
@@ -18,11 +18,14 @@ module.exports = function (name, version) {
 		}
 
 		headers.authorization = 'Bearer ' + token;
+	} else if(npmrc._auth) {
+		auth = new Buffer(npmrc._auth, 'base64').toString('utf-8');
 	}
 
 	return got(url, {
 		json: true,
-		headers: headers
+		headers: headers,
+		auth: auth
 	})
 		.then(function (res) {
 			var data = res.body;


### PR DESCRIPTION
Add the ability to call registry with basic auth if _auth is present in npm config.

I have a npmrc looks like : 
```
email=login@domain.com
_auth=BASIC_64_ENCODED
registry=http://my-private-npm.com
username=login
always-auth=true
```

Before this patch : `Basic authentication must be done with auth option`

After i have good data.
