### PR TITLE
stop sending registery.npmjs.org authToken to other npm registeries

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@ module.exports = function (name, version) {
 	var scope = name.split('/')[0];
 	var pkgUrl = url.resolve(registryUrl(scope), encodeURIComponent(name).replace(/^%40/, '@'));
 	var npmrc = rc('npm');
-	var token = npmrc[scope + ':_authToken'] || npmrc['//registry.npmjs.org/:_authToken'];
+	var token;
+	if (!npmrc.registry || url.parse(npmrc.registry).hostname === 'registry.npmjs.org') {
+		token = npmrc[scope + ':_authToken'] || npmrc['//registry.npmjs.org/:_authToken'];
+	}
 	var headers = {};
 
 	if (token) {


### PR DESCRIPTION
this could be considered as a security fix.
but it also makes the module work with fury.io, because they always deny access if authorisation header is set, because they provide the authToken right in the url (don't ask me why).