### PR TITLE
Allow resolving by dist tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ module.exports = (name, version) => {
 		.then(res => {
 			let data = res.body;
 
-			if (version === 'latest') {
-				data = data.versions[data['dist-tags'].latest];
+			if (data['dist-tags'][version]) {
+				data = data.versions[data['dist-tags'][version]];
 			} else if (version) {
 				if (!data.versions[version]) {
 					const versions = Object.keys(data.versions);

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ packageJson('@company/package', 'latest').then(json => {
 
 ### packageJson(name, [version])
 
-You can optionally specify a version (e.g. `1.0.0`) or `latest`. If you don't specify a version you'll get the [main entry](http://registry.npmjs.org/pageres/) containing all versions.
+You can optionally specify a version (e.g. `1.0.0`) or a [dist tag](https://docs.npmjs.com/cli/dist-tag) such as `latest`. If you don't specify a version you'll get the [main entry](http://registry.npmjs.org/pageres/) containing all versions.
 
 The version can also be in any format supported by the [semver](https://www.npmjs.com/package/semver) module. For example:
 

--- a/test.js
+++ b/test.js
@@ -40,6 +40,11 @@ test('scoped - specific version', async t => {
 	t.is(json.version, '1.0.1');
 });
 
+test('scoped - dist tag', async t => {
+	const json = await m('@rexxars/npmtest', 'next');
+	t.is(json.version, '2.0.0');
+});
+
 test('reject when version doesn\'t exist', async t => {
 	t.throws(m('hapi', '6.6.6'), 'Version doesn\'t exist');
 });
@@ -50,7 +55,7 @@ test('reject when package doesn\'t exist', async t => {
 
 test.cb('does not send any auth token for unconfigured registries', t => {
 	const server = http.createServer((req, res) => {
-		res.end(JSON.stringify({headers: req.headers}));
+		res.end(JSON.stringify({headers: req.headers, 'dist-tags': {}}));
 	});
 
 	server.listen(63144, '127.0.0.1', async () => {


### PR DESCRIPTION
Currently, we only support version ranges or the explicit "latest" dist-tag.
This PR makes it possible to resolve data for any dist-tag.

The NPM documentation says the following about dist-tags:
> Tags that can be interpreted as valid semver ranges will be rejected

So it should be safe to assume that we can check for a dist-tag with the given name first, then fall back to checking for a matching version.

