### PR TITLE
Recursively evaluate authInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = (name, opts) => {
 	const scope = name.split('/')[0];
 	const regUrl = registryUrl(scope);
 	const pkgUrl = url.resolve(regUrl, encodeURIComponent(name).replace(/^%40/, '@'));
-	const authInfo = registryAuthToken(regUrl);
+	const authInfo = registryAuthToken(regUrl, { recursive: true });
 
 	opts = Object.assign({
 		version: 'latest'

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = (name, opts) => {
 	const scope = name.split('/')[0];
 	const regUrl = registryUrl(scope);
 	const pkgUrl = url.resolve(regUrl, encodeURIComponent(name).replace(/^%40/, '@'));
-	const authInfo = registryAuthToken(regUrl, { recursive: true });
+	const authInfo = registryAuthToken(regUrl, {recursive: true});
 
 	opts = Object.assign({
 		version: 'latest'


### PR DESCRIPTION
NPM supports a recursive evaluation to associate the authToken URL with the registry URL. This allows someone to have something like:
```
@foo:registry=https://contoso.visualstudio.com/_packaging/foo-registry/npm/registry
@bar:registry=https://contoso.visualstudio.com/_packaging/bar-registry/npm/registry
//contoso.visualstudio.com/_packaging:_authToken=....
```

However, since we have recursion turned off, this package will fail to find the auth credentials in these cases.

This PR should have a relatively low risk of regression, since we would be (incorrectly) unable to find credentials if someone is doing this now.