### PR TITLE
Bump `got` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "scoped"
   ],
   "dependencies": {
-    "got": "^6.7.1",
+    "got": "^8.0.1",
     "registry-auth-token": "^3.0.1",
     "registry-url": "^3.0.3",
     "semver": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "scoped"
   ],
   "dependencies": {
-    "got": "^8.0.1",
+    "got": "^8.3.1",
     "registry-auth-token": "^3.0.1",
     "registry-url": "^3.0.3",
     "semver": "^5.1.0"


### PR DESCRIPTION
All other deps up to date.

This update found due to `npm i --prod` installing two copies of `got`.  The latest for my app and 6.7.1 via `update-notifier`.