### PR TITLE
Use keepAlive agent to increase performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,20 @@
 'use strict';
 const {URL} = require('url');
+const {Agent: HttpAgent} = require('http');
+const {Agent: HttpsAgent} = require('https');
 const got = require('got');
 const registryUrl = require('registry-url');
 const registryAuthToken = require('registry-auth-token');
 const semver = require('semver');
+
+// These agent options are chosen to match the npm client defaults and help with performance
+// see: `npm config get maxsockets` and #50
+const agentOptions = {
+	keepAlive: true,
+	maxSockets: 50
+};
+const httpAgent = new HttpAgent(agentOptions);
+const httpsAgent = new HttpsAgent(agentOptions);
 
 class PackageNotFoundError extends Error {
 	constructor(packageName) {
@@ -44,7 +55,15 @@ module.exports = async (name, options) => {
 
 	let response;
 	try {
-		response = await got(pkgUrl, {json: true, headers});
+		const gotOptions = {
+			json: true,
+			headers,
+			agent: {
+				http: httpAgent,
+				https: httpsAgent
+			}
+		};
+		response = await got(pkgUrl, gotOptions);
 	} catch (error) {
 		if (error.statusCode === 404) {
 			throw new PackageNotFoundError(name);


### PR DESCRIPTION
Thanks for your work on package-json!

When dealing with a lot of `package.json` dependencies, not using a `keepAlive` Agent results in performance penalties.

example.js

```js
const packageJson = require('package-json');
const packages = new Array(1000).fill('package-json');
packages.map(packageJson);
```

Without keepAlive (2minutes):
```
$ time node example.js 
real	2m12.209s
```

With keepAlive (3 seconds):
```
$ time node example.js 
real	0m3.395s
```

The npm client uses the same configuration [under the hood](https://github.com/npm/npm-registry-client/blob/14efa6848ca1e7278de0eb12a1430cdb85bddf02/lib/initialize.js#L69-L70).

Also added the ability to pass down options to `got` since I touched that part of the code anyway.