### PR TITLE
Add `agent` option (for proxy support)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,11 @@
 import {Agent as HttpAgent} from 'http';
 import {Agent as HttpsAgent} from 'https';
 
+export interface AgentOptions {
+	http?: HttpAgent;
+	https?: HttpsAgent;
+}
+
 export interface Options {
 	/**
 	 * Package version such as `1.0.0` or a [dist tag](https://docs.npmjs.com/cli/dist-tag) such as `latest`.
@@ -37,7 +42,7 @@ export interface Options {
 	/**
 	 * Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
 	 */
-	readonly agent?: http.Agent | boolean | AgentOptions;
+	readonly agent?: HttpAgent | HttpsAgent | boolean | AgentOptions;
 }
 
 export interface FullMetadataOptions extends Options {
@@ -131,11 +136,6 @@ export interface FullVersion extends AbbreviatedVersion, HoistedData {
 	readonly types?: string;
 	readonly typings?: string;
 	readonly [key: string]: unknown;
-}
-
-export interface AgentOptions {
-	http: HttpAgent;
-	https: HttpsAgent;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,6 @@
+import {Agent as HttpAgent} from 'http';
+import {Agent as HttpsAgent} from 'https';
+
 export interface Options {
 	/**
 	 * Package version such as `1.0.0` or a [dist tag](https://docs.npmjs.com/cli/dist-tag) such as `latest`.
@@ -30,6 +33,11 @@ export interface Options {
 	 * The registry URL is by default inferred from the npm defaults and `.npmrc`. This is beneficial as `package-json` and any project using it will work just like npm. This option is **only** intended for internal tools. You should **not** use this option in reusable packages. Prefer just using `.npmrc` whenever possible.
 	 */
 	readonly registryUrl?: string;
+
+	/**
+	 * Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
+	 */
+	readonly agent?: http.Agent | boolean | AgentOptions;
 }
 
 export interface FullMetadataOptions extends Options {
@@ -123,6 +131,11 @@ export interface FullVersion extends AbbreviatedVersion, HoistedData {
 	readonly types?: string;
 	readonly typings?: string;
 	readonly [key: string]: unknown;
+}
+
+export interface AgentOptions {
+	http: HttpAgent;
+	https: HttpsAgent;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ export interface Options {
 	/**
 	 * Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
 	 */
-	readonly agent?: HttpAgent | HttpsAgent | boolean | AgentOptions;
+	readonly agent?: HttpAgent | HttpsAgent | AgentOptions | false;
 }
 
 export interface FullMetadataOptions extends Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {Agent as HttpAgent} from 'http';
 import {Agent as HttpsAgent} from 'https';
 
-export interface AgentOptions {
+export interface Agents {
 	http?: HttpAgent;
 	https?: HttpsAgent;
 }
@@ -40,9 +40,9 @@ export interface Options {
 	readonly registryUrl?: string;
 
 	/**
-	 * Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
+	 * Overwrite the `agent` option that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
 	 */
-	readonly agent?: HttpAgent | HttpsAgent | AgentOptions | false;
+	readonly agent?: HttpAgent | HttpsAgent | Agents | false;
 }
 
 export interface FullMetadataOptions extends Options {

--- a/index.js
+++ b/index.js
@@ -62,6 +62,10 @@ const packageJson = async (packageName, options) => {
 		}
 	};
 
+	if (options.agent) {
+		gotOptions.agent = options.agent;
+	}
+
 	let response;
 	try {
 		response = await got(packageUrl, gotOptions);

--- a/readme.md
+++ b/readme.md
@@ -76,9 +76,9 @@ The registry URL is by default inferred from the npm defaults and `.npmrc`. This
 
 ##### agent
 
-Type: `Object`
+Type: `http.Agent | https.Agent | Object | false`
 
-Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
+Overwrite the `agent` option that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
 
 
 ### packageJson.PackageNotFoundError

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,13 @@ Default: Auto-detected
 
 The registry URL is by default inferred from the npm defaults and `.npmrc`. This is beneficial as `package-json` and any project using it will work just like npm. This option is **only** intended for internal tools. You should **not** use this option in reusable packages. Prefer just using `.npmrc` whenever possible.
 
+##### agent
+
+Type: `object`
+
+Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent).
+
+
 ### packageJson.PackageNotFoundError
 
 The error thrown when the given package name cannot be found.

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ The registry URL is by default inferred from the npm defaults and `.npmrc`. This
 
 ##### agent
 
-Type: `object`
+Type: `Object`
 
 Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent).
 

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ The registry URL is by default inferred from the npm defaults and `.npmrc`. This
 
 Type: `Object`
 
-Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent).
+Overwrite the `agent` that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
 
 
 ### packageJson.PackageNotFoundError


### PR DESCRIPTION
Since [direct proxy support should not be added](https://github.com/sindresorhus/package-json/issues/22#issuecomment-185158091), allow instead to define the `agent` option in order to be able to implement [consumer](https://github.com/tjunnone/npm-check-updates/issues/521) proxy support using [tunnel](https://github.com/koichik/node-tunnel) as suggested by [got](https://github.com/sindresorhus/got#proxies).

[You already said](https://github.com/sindresorhus/package-json/pull/50#discussion_r264597014) that you don't want to pass down options to `got`, but maybe you want to consider making an exception for the `agent` option in order to support proxies. That would be neat. If not, feel free to close. Thanks!