### PR TITLE
feat: respect global proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ const got = require('got');
 const registryUrl = require('registry-url');
 const registryAuthToken = require('registry-auth-token');
 const semver = require('semver');
+const globalTunnul = require('global-tunnel-ng');
+
+// Init global proxy
+globalTunnul.initialize();
 
 // These agent options are chosen to match the npm client defaults and help with performance
 // See: `npm config get maxsockets` and #50

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"scoped"
 	],
 	"dependencies": {
+		"global-tunnel-ng": "^2.7.1",
 		"got": "^9.6.0",
 		"registry-auth-token": "^4.0.0",
 		"registry-url": "^5.0.0",


### PR DESCRIPTION
If users configured proxys global, it will get a `ECONNREFUSED` error, because `got` lib ignored it. Refer to this issue https://github.com/sindresorhus/got/issues/560, so we need [global-tunnel-ng](https://github.com/np-maintain/global-tunnel).