### PR TITLE
bump `got` dependency to 12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"scoped"
 	],
 	"dependencies": {
-		"got": "^11.8.2",
+		"got": "^12.0.0",
 		"registry-auth-token": "^4.0.0",
 		"registry-url": "^5.0.0",
 		"semver": "^7.3.5"


### PR DESCRIPTION
Bumping the got dependency removes the nested dependency on `normalize-url@4.5.0` which has a security vulnerability fixed in `5.3.1`

