### PR TITLE
Upgrade `registry-auth-token` to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	],
 	"dependencies": {
 		"got": "^12.1.0",
-		"registry-auth-token": "^4.2.1",
+		"registry-auth-token": "^5.0.1",
 		"registry-url": "^6.0.0",
 		"semver": "^7.3.7"
 	},


### PR DESCRIPTION
`registry-auth-token@5` replaces the unmaintained `rc` module with `@pnpm/npm-conf`, and modernizes the code to only support node 14 and higher. Should be backwards compatible given this module now _also_ only supports node 14 and above.