### PR TITLE
fix: include `time` metadata for specific versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,9 @@ export default async function packageJson(packageName, options) {
 	const versionError = new VersionNotFoundError(packageName, version);
 
 	if (data['dist-tags'][version]) {
+		const time = data.time;
 		data = data.versions[data['dist-tags'][version]];
+		data.time = time;
 	} else if (version) {
 		if (!data.versions[version]) {
 			const versions = Object.keys(data.versions);
@@ -94,7 +96,9 @@ export default async function packageJson(packageName, options) {
 			}
 		}
 
+		const time = data.time;
 		data = data.versions[version];
+		data.time = time;
 
 		if (!data) {
 			throw versionError;

--- a/test.js
+++ b/test.js
@@ -17,6 +17,8 @@ test('full metadata', async t => {
 	});
 	t.is(json.name, 'pageres');
 	t.is(json._id, 'pageres@4.4.0');
+	t.is(json.time.created, '2014-02-07T18:17:46.737Z');
+	t.is(json.time.modified, '2022-10-27T08:57:30.321Z');
 });
 
 test('all version', async t => {
@@ -53,6 +55,8 @@ test('scoped - full metadata', async t => {
 	});
 	t.is(json.name, '@sindresorhus/df');
 	t.is(json._id, '@sindresorhus/df@1.0.1');
+	t.is(json.time.created, '2015-05-04T18:10:02.416Z');
+	t.is(json.time.modified, '2022-06-12T23:49:38.166Z');
 });
 
 test('scoped - all version', async t => {


### PR DESCRIPTION
The `time` metadata field is missing when `allVersions` is false.