### PR TITLE
Modernize tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 21
           - 20
           # - 18
     steps:

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,7 @@
 package-lock=false
 
 @mockscope:registry=http://localhost:63142
-//localhost:63142/:_authToken=MySecretToken
+//localhost:63142/:_authToken=SecretToken
 
 @mockscope2:registry=http://localhost:63143
 //localhost:63143/:username=Aladdin

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ export type FullMetadataOptions = {
 	readonly fullMetadata: true;
 } & Options;
 
+// eslint-disable-next-line unicorn/prevent-abbreviations
 type DistTags = {
 	readonly [tagName: string]: string;
 	readonly latest: string;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	"devDependencies": {
 		"@types/node": "^20.11.5",
 		"ava": "^6.1.0",
-		"mock-private-registry": "^1.1.2",
+		"private-registry-mock": "^0.2.0",
 		"tsd": "^0.30.4",
 		"xo": "^0.56.0"
 	}

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
 		"got": "^13.0.0",
 		"registry-auth-token": "^5.0.2",
 		"registry-url": "^6.0.1",
-		"semver": "^7.5.4"
+		"semver": "^7.6.0"
 	},
 	"devDependencies": {
 		"@types/node": "^20.11.5",
-		"ava": "^6.1.0",
+		"ava": "^6.1.1",
 		"private-registry-mock": "^0.2.0",
-		"tsd": "^0.30.4",
-		"xo": "^0.56.0"
+		"tsd": "^0.30.5",
+		"xo": "^0.57.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,13 +1,16 @@
 import {promisify} from 'node:util';
 import http from 'node:http';
 import test from 'ava';
-import privateRegistry from 'mock-private-registry/promise.js';
+import privateRegistry from 'private-registry-mock';
 import packageJson, {PackageNotFoundError, VersionNotFoundError} from './index.js';
 
 test('latest version', async t => {
 	const json = await packageJson('ava');
-	t.is(json.name, 'ava');
-	t.falsy(json.versions);
+
+	t.like(json, {
+		name: 'ava',
+		versions: undefined,
+	});
 });
 
 test('full metadata', async t => {
@@ -15,20 +18,33 @@ test('full metadata', async t => {
 		fullMetadata: true,
 		version: '4.4.0',
 	});
-	t.is(json.name, 'pageres');
-	t.is(json._id, 'pageres@4.4.0');
-	t.is(json.time.created, '2014-02-07T18:17:46.737Z');
+
+	t.like(json, {
+		name: 'pageres',
+		_id: 'pageres@4.4.0',
+		time: {
+			created: '2014-02-07T18:17:46.737Z',
+		},
+	});
 });
 
 test('all version', async t => {
 	const json = await packageJson('pageres', {allVersions: true});
-	t.is(json.name, 'pageres');
-	t.is(json.versions['0.1.0'].name, 'pageres');
+
+	t.like(json, {
+		name: 'pageres',
+		versions: {
+			'0.1.0': {name: 'pageres'},
+		},
+	});
 });
 
 test('specific version', async t => {
 	const json = await packageJson('pageres', {version: '0.1.0'});
-	t.is(json.version, '0.1.0');
+
+	t.like(json, {
+		version: '0.1.0',
+	});
 });
 
 test('incomplete version x', async t => {
@@ -45,7 +61,10 @@ test('incomplete version x', async t => {
 
 test('scoped - latest version', async t => {
 	const json = await packageJson('@sindresorhus/df');
-	t.is(json.name, '@sindresorhus/df');
+
+	t.like(json, {
+		name: '@sindresorhus/df',
+	});
 });
 
 test('scoped - full metadata', async t => {
@@ -53,26 +72,42 @@ test('scoped - full metadata', async t => {
 		fullMetadata: true,
 		version: '1.0.1',
 	});
-	t.is(json.name, '@sindresorhus/df');
-	t.is(json._id, '@sindresorhus/df@1.0.1');
-	t.is(json.time.created, '2015-05-04T18:10:02.416Z');
-	t.is(json.time.modified, '2022-06-12T23:49:38.166Z');
+
+	t.like(json, {
+		name: '@sindresorhus/df',
+		_id: '@sindresorhus/df@1.0.1',
+		time: {
+			created: '2015-05-04T18:10:02.416Z',
+			modified: '2022-06-12T23:49:38.166Z',
+		},
+	});
 });
 
 test('scoped - all version', async t => {
 	const json = await packageJson('@sindresorhus/df', {allVersions: true});
-	t.is(json.name, '@sindresorhus/df');
-	t.is(json.versions['1.0.1'].name, '@sindresorhus/df');
+
+	t.like(json, {
+		name: '@sindresorhus/df',
+		versions: {
+			'1.0.1': {name: '@sindresorhus/df'},
+		},
+	});
 });
 
 test('scoped - specific version', async t => {
 	const json = await packageJson('@sindresorhus/df', {version: '1.0.1'});
-	t.is(json.version, '1.0.1');
+
+	t.like(json, {
+		version: '1.0.1',
+	});
 });
 
 test('scoped - dist tag', async t => {
 	const json = await packageJson('@rexxars/npmtest', {version: 'next'});
-	t.is(json.version, '2.0.0');
+
+	t.like(json, {
+		version: '2.0.0',
+	});
 });
 
 test('reject when package doesn\'t exist', async t => {
@@ -89,27 +124,45 @@ test('does not send any auth token for unconfigured registries', async t => {
 	});
 
 	await promisify(server.listen.bind(server))(63_144, '127.0.0.1');
+	console.log('listening!');
 	const json = await packageJson('@mockscope3/foobar', {allVersions: true});
-	t.is(json.headers.host, 'localhost:63144');
-	t.is(json.headers.authorization, undefined);
+	console.log('fetchd!');
+
+	t.like(json.headers, {
+		host: 'localhost:63144',
+		authorization: undefined,
+	});
+
 	await promisify(server.close.bind(server))();
 });
 
 test('private registry (bearer token)', async t => {
-	const server = await privateRegistry();
+	const server = await privateRegistry({port: 63_142});
 	const json = await packageJson('@mockscope/foobar');
-	t.is(json.name, '@mockscope/foobar');
+
+	t.like(json, {
+		name: '@mockscope/foobar',
+	});
+
 	server.close();
 });
 
 test('private registry (basic token)', async t => {
 	const server = await privateRegistry({
 		port: 63_143,
-		pkgName: '@mockscope2/foobar',
-		token: 'QWxhZGRpbjpPcGVuU2VzYW1l',
-		tokenType: 'Basic',
+		package: {
+			name: '@mockscope2/foobar',
+		},
+		token: {
+			type: 'basic',
+			value: 'QWxhZGRpbjpPcGVuU2VzYW1l', // Aladdin:OpenSesame
+		},
 	});
 	const json = await packageJson('@mockscope2/foobar');
-	t.is(json.name, '@mockscope2/foobar');
+
+	t.like(json, {
+		name: '@mockscope2/foobar',
+	});
+
 	server.close();
 });

--- a/test.js
+++ b/test.js
@@ -124,9 +124,7 @@ test('does not send any auth token for unconfigured registries', async t => {
 	});
 
 	await promisify(server.listen.bind(server))(63_144, '127.0.0.1');
-	console.log('listening!');
 	const json = await packageJson('@mockscope3/foobar', {allVersions: true});
-	console.log('fetchd!');
 
 	t.like(json.headers, {
 		host: 'localhost:63144',


### PR DESCRIPTION
Switches tests to use `t.like` and updates dependencies.

I've also swapped https://github.com/rexxars/mock-private-registry for https://github.com/tommy-mitchell/private-registry-mock. I've tried to follow the original while modernizing where it makes sense to. What do you think? Thought it might be useful for np as well.

---

I'm planning on doing a couple of PRs e.g. for fixing the types. Re: #74, would `ky` be something you'd be interested in switching to, now that it works in both the browser and Node.js?