### PR TITLE
Switch from `got` to `ky`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,3 @@
-import {Agent as HttpAgent} from 'node:http';
-import {Agent as HttpsAgent} from 'node:https';
-import {type Agents} from 'got';
-
 /**
 The error thrown when the given package version cannot be found.
 */
@@ -52,11 +48,6 @@ export type Options = {
 	The registry URL is by default inferred from the npm defaults and `.npmrc`. This is beneficial as `package-json` and any project using it will work just like npm. This option is*only** intended for internal tools. You should __not__ use this option in reusable packages. Prefer just using `.npmrc` whenever possible.
 	*/
 	readonly registryUrl?: string;
-
-	/**
-	Overwrite the `agent` option that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
-	*/
-	readonly agent?: Agents;
 };
 
 export type FullMetadataOptions = {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import {Agent as HttpAgent} from 'node:http';
 import {Agent as HttpsAgent} from 'node:https';
-import got from 'got';
+import ky from 'ky';
 import registryUrl from 'registry-url';
 import registryAuthToken from 'registry-auth-token';
 import semver from 'semver';
@@ -52,23 +52,17 @@ export default async function packageJson(packageName, options) {
 		headers.authorization = `${authInfo.type} ${authInfo.token}`;
 	}
 
-	const gotOptions = {
-		headers,
-		agent: {
-			http: httpAgent,
-			https: httpsAgent,
-		},
-	};
-
-	if (options.agent) {
-		gotOptions.agent = options.agent;
-	}
-
 	let data;
 	try {
-		data = await got(packageUrl, gotOptions).json();
+		data = await ky(packageUrl, {
+			headers,
+			agent: options.agent ?? {
+				http: httpAgent,
+				https: httpsAgent,
+			},
+		}).json();
 	} catch (error) {
-		if (error?.response?.statusCode === 404) {
+		if (error?.response?.status === 404) {
 			throw new PackageNotFoundError(packageName);
 		}
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,7 @@
-import {Agent as HttpAgent} from 'node:http';
-import {Agent as HttpsAgent} from 'node:https';
 import ky from 'ky';
 import registryUrl from 'registry-url';
 import registryAuthToken from 'registry-auth-token';
 import semver from 'semver';
-
-// These agent options are chosen to match the npm client defaults and help with performance
-// See: `npm config get maxsockets` and #50
-const agentOptions = {
-	keepAlive: true,
-	maxSockets: 50,
-};
-
-const httpAgent = new HttpAgent(agentOptions);
-const httpsAgent = new HttpsAgent(agentOptions);
 
 export class PackageNotFoundError extends Error {
 	constructor(packageName) {
@@ -54,13 +42,7 @@ export default async function packageJson(packageName, options) {
 
 	let data;
 	try {
-		data = await ky(packageUrl, {
-			headers,
-			agent: options.agent ?? {
-				http: httpAgent,
-				https: httpsAgent,
-			},
-		}).json();
+		data = await ky(packageUrl, {headers, keepalive: true}).json();
 	} catch (error) {
 		if (error?.response?.status === 404) {
 			throw new PackageNotFoundError(packageName);

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"//test": "xo && ava && tsd",
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -39,7 +38,7 @@
 		"scoped"
 	],
 	"dependencies": {
-		"got": "^13.0.0",
+		"ky": "^1.2.0",
 		"registry-auth-token": "^5.0.2",
 		"registry-url": "^6.0.1",
 		"semver": "^7.6.0"

--- a/readme.md
+++ b/readme.md
@@ -69,12 +69,6 @@ Default: Auto-detected
 
 The registry URL is by default inferred from the npm defaults and `.npmrc`. This is beneficial as `package-json` and any project using it will work just like npm. This option is **only** intended for internal tools. You should **not** use this option in reusable packages. Prefer just using `.npmrc` whenever possible.
 
-##### agent
-
-Type: `object`
-
-Overwrite the `agent` option that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
-
 ### PackageNotFoundError
 
 The error thrown when the given package name cannot be found.
@@ -86,6 +80,12 @@ The error thrown when the given package version cannot be found.
 ## Authentication
 
 Both public and private registries are supported, for both scoped and unscoped packages, as long as the registry uses either bearer tokens or basic authentication.
+
+## Proxies
+
+Proxy support is not implemented in this package. If necessary, use a global agent that modifies `fetch`.
+
+Support for this may come to [Node.js in the future](https://github.com/nodejs/undici/issues/1650).
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ Both public and private registries are supported, for both scoped and unscoped p
 
 ## Proxies
 
-Proxy support is not implemented in this package. If necessary, use a global agent that modifies `fetch`.
+Proxy support is not implemented in this package. If necessary, use a global agent that modifies [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), which this package uses internally.
 
 Support for this may come to [Node.js in the future](https://github.com/nodejs/undici/issues/1650).
 


### PR DESCRIPTION
Per #75. Supersedes #74 and re-enables `tsd` tests.

How should proxy support work? Seeing as `ky` doesn't support proxies: https://github.com/sindresorhus/ky/issues/526

https://github.com/sindresorhus/package-json/blob/7238462e0b36d8344cca6fdbf0abd6ece84d0b9a/index.js#L55-L65