### PR TITLE
Omit deprecated versions by default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ export type Options = {
 
 	@default true
 	*/
-	readonly ignoreDeprecated?: boolean;
+	readonly omitDeprecated?: boolean;
 };
 
 export type FullMetadataOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,9 @@ export type Options = {
 	readonly registryUrl?: string;
 
 	/**
-	Whether or not to omit deprecated versions of a package. Has no effect if a dist tag or a specific version is provided.
+	Whether or not to omit deprecated versions of a package.
+
+	If set, versions marked as deprecated on the registry are omitted from results. Providing a dist tag or a specific version will still return that version, even if it's deprecated. If no version can be found once deprecated versions are omitted, a `VersionNotFoundError` is thrown.
 
 	@default true
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,13 @@ export type Options = {
 	Overwrite the `agent` option that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
 	*/
 	readonly agent?: Agents;
+
+	/**
+	Whether or not to omit deprecated versions of a package. Has no effect if a dist tag or a specific version is provided.
+
+	@default true
+	*/
+	readonly ignoreDeprecated?: boolean;
 };
 
 export type FullMetadataOptions = {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ export class VersionNotFoundError extends Error {
 export default async function packageJson(packageName, options) {
 	options = {
 		version: 'latest',
-		ignoreDeprecated: true,
+		omitDeprecated: true,
 		...options,
 	};
 
@@ -66,7 +66,7 @@ export default async function packageJson(packageName, options) {
 	} else if (version) {
 		const versionExists = Boolean(data.versions[version]);
 
-		if (options.ignoreDeprecated && !versionExists) {
+		if (options.omitDeprecated && !versionExists) {
 			for (const [metadataVersion, metadata] of Object.entries(data.versions)) {
 				if (metadata.deprecated) {
 					delete data.versions[metadataVersion];

--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ export default async function packageJson(packageName, options) {
 			}
 		}
 
-		// TODO: is this still valid here, or does it need to be recalculated?
 		if (!versionExists) {
 			const versions = Object.keys(data.versions);
 			version = semver.maxSatisfying(versions, version);

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export class VersionNotFoundError extends Error {
 export default async function packageJson(packageName, options) {
 	options = {
 		version: 'latest',
+		omitDeprecated: true,
 		...options,
 	};
 
@@ -87,7 +88,18 @@ export default async function packageJson(packageName, options) {
 		data = data.versions[data['dist-tags'][version]];
 		data.time = time;
 	} else if (version) {
-		if (!data.versions[version]) {
+		const versionExists = Boolean(data.versions[version]);
+
+		if (options.omitDeprecated && !versionExists) {
+			for (const [metadataVersion, metadata] of Object.entries(data.versions)) {
+				if (metadata.deprecated) {
+					delete data.versions[metadataVersion];
+				}
+			}
+		}
+
+		// TODO: is this still valid here, or does it need to be recalculated?
+		if (!versionExists) {
 			const versions = Object.keys(data.versions);
 			version = semver.maxSatisfying(versions, version);
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ export class VersionNotFoundError extends Error {
 export default async function packageJson(packageName, options) {
 	options = {
 		version: 'latest',
-		omitDeprecated: true,
+		ignoreDeprecated: true,
 		...options,
 	};
 
@@ -90,7 +90,7 @@ export default async function packageJson(packageName, options) {
 	} else if (version) {
 		const versionExists = Boolean(data.versions[version]);
 
-		if (options.omitDeprecated && !versionExists) {
+		if (options.ignoreDeprecated && !versionExists) {
 			for (const [metadataVersion, metadata] of Object.entries(data.versions)) {
 				if (metadata.deprecated) {
 					delete data.versions[metadataVersion];

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Default: Auto-detected
 
 The registry URL is by default inferred from the npm defaults and `.npmrc`. This is beneficial as `package-json` and any project using it will work just like npm. This option is **only** intended for internal tools. You should **not** use this option in reusable packages. Prefer just using `.npmrc` whenever possible.
 
-##### ignoreDeprecated
+##### omitDeprecated
 
 Type: `boolean`\
 Default: `true`

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,9 @@ The registry URL is by default inferred from the npm defaults and `.npmrc`. This
 Type: `boolean`\
 Default: `true`
 
-Whether or not to omit deprecated versions of a package. Has no effect if a dist tag or a specific version is provided.
+Whether or not to omit deprecated versions of a package.
+
+If set, versions marked as deprecated on the registry are omitted from results. Providing a dist tag or a specific version will still return that version, even if it's deprecated. If no version can be found once deprecated versions are omitted, a [`VersionNotFoundError`](#versionnotfounderror) is thrown.
 
 ### PackageNotFoundError
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,13 @@ Type: `object`
 
 Overwrite the `agent` option that is passed down to [`got`](https://github.com/sindresorhus/got#agent). This might be useful to add [proxy support](https://github.com/sindresorhus/got#proxies).
 
+##### ignoreDeprecated
+
+Type: `boolean`\
+Default: `true`
+
+Whether or not to omit deprecated versions of a package. Has no effect if a dist tag or a specific version is provided.
+
 ### PackageNotFoundError
 
 The error thrown when the given package name cannot be found.

--- a/test.js
+++ b/test.js
@@ -211,4 +211,3 @@ test('does not omit specific deprecated versions', async t => {
 		deprecated: 'this package version has been deprecated as it was released by mistake',
 	});
 });
-

--- a/test.js
+++ b/test.js
@@ -52,12 +52,14 @@ test('incomplete version x', async t => {
 	t.is(json.version.slice(0, 2), '0.');
 });
 
-// TODO: Find an alternative npm instance.
-// test.failing('custom registry url', async t => {
-// 	const json = await packageJson('ava', {registryUrl: 'https://npm.open-registry.dev/'});
-// 	t.is(json.name, 'ava');
-// 	t.falsy(json.versions);
-// });
+test('custom registry url', async t => {
+	const json = await packageJson('ava', {registryUrl: 'https://registry.yarnpkg.com'});
+
+	t.like(json, {
+		name: 'ava',
+		versions: undefined,
+	});
+});
 
 test('scoped - latest version', async t => {
 	const json = await packageJson('@sindresorhus/df');

--- a/test.js
+++ b/test.js
@@ -176,7 +176,7 @@ test('omits deprecated versions by default', async t => {
 });
 
 test('optionally includes deprecated versions', async t => {
-	const json = await packageJson('ng-packagr', {version: '14', ignoreDeprecated: false});
+	const json = await packageJson('ng-packagr', {version: '14', omitDeprecated: false});
 
 	t.like(json, {
 		name: 'ng-packagr',

--- a/test.js
+++ b/test.js
@@ -176,7 +176,7 @@ test('omits deprecated versions by default', async t => {
 });
 
 test('optionally includes deprecated versions', async t => {
-	const json = await packageJson('ng-packagr', {version: '14', omitDeprecated: false});
+	const json = await packageJson('ng-packagr', {version: '14', ignoreDeprecated: false});
 
 	t.like(json, {
 		name: 'ng-packagr',

--- a/test.js
+++ b/test.js
@@ -164,3 +164,51 @@ test('private registry (basic token)', async t => {
 
 	server.close();
 });
+
+test('omits deprecated versions by default', async t => {
+	const json = await packageJson('ng-packagr', {version: '14'});
+
+	t.like(json, {
+		name: 'ng-packagr',
+		version: '14.2.2',
+		deprecated: undefined,
+	});
+});
+
+test('optionally includes deprecated versions', async t => {
+	const json = await packageJson('ng-packagr', {version: '14', omitDeprecated: false});
+
+	t.like(json, {
+		name: 'ng-packagr',
+		version: '14.3.0',
+		deprecated: 'this package version has been deprecated as it was released by mistake',
+	});
+});
+
+test('errors if all versions are deprecated', async t => {
+	await t.throwsAsync(
+		packageJson('querystring', {version: '0'}),
+		{instanceOf: VersionNotFoundError},
+	);
+});
+
+test('does not omit specific deprecated dist tags', async t => {
+	const json = await packageJson('querystring', {version: 'latest'});
+
+	t.like(json, {
+		name: 'querystring',
+		version: '0.2.1',
+		deprecated: 'The querystring API is considered Legacy. new code should use the URLSearchParams API instead.',
+	});
+});
+
+test('does not omit specific deprecated versions', async t => {
+	const json = await packageJson('ng-packagr', {version: '14.3.0'});
+
+	t.like(json, {
+		name: 'ng-packagr',
+		version: '14.3.0',
+		deprecated: 'this package version has been deprecated as it was released by mistake',
+	});
+});
+


### PR DESCRIPTION
Closes #70.

Adds a new `omitDeprecated` option (`true` by default). If set, versions marked as deprecated on the registry are omitted from results. Providing a dist tag or a specific version will still return that version, even if it's deprecated. If no version can be found once deprecated versions are omitted, a `VersionNotFoundError` is thrown.