### PR TITLE
Improve handling of default options

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ export class VersionNotFoundError extends Error {
 }
 
 export default async function packageJson(packageName, options = {}) {
-	options.version ??= 'latest';
-	options.omitDeprecated ??= true;
+	let {version = 'latest'} = options;
+	const {omitDeprecated = true} = options;
 
 	const scope = packageName.split('/')[0];
 	const registryUrl_ = options.registryUrl ?? registryUrl(scope);
@@ -53,7 +53,6 @@ export default async function packageJson(packageName, options = {}) {
 		return data;
 	}
 
-	let {version} = options;
 	const versionError = new VersionNotFoundError(packageName, version);
 
 	if (data['dist-tags'][version]) {
@@ -63,7 +62,7 @@ export default async function packageJson(packageName, options = {}) {
 	} else if (version) {
 		const versionExists = Boolean(data.versions[version]);
 
-		if (options.omitDeprecated && !versionExists) {
+		if (omitDeprecated && !versionExists) {
 			for (const [metadataVersion, metadata] of Object.entries(data.versions)) {
 				if (metadata.deprecated) {
 					delete data.versions[metadataVersion];

--- a/index.js
+++ b/index.js
@@ -17,15 +17,12 @@ export class VersionNotFoundError extends Error {
 	}
 }
 
-export default async function packageJson(packageName, options) {
-	options = {
-		version: 'latest',
-		omitDeprecated: true,
-		...options,
-	};
+export default async function packageJson(packageName, options = {}) {
+	options.version ??= 'latest';
+	options.omitDeprecated ??= true;
 
 	const scope = packageName.split('/')[0];
-	const registryUrl_ = options.registryUrl || registryUrl(scope);
+	const registryUrl_ = options.registryUrl ?? registryUrl(scope);
 	const packageUrl = new URL(encodeURIComponent(packageName).replace(/^%40/, '@'), registryUrl_);
 	const authInfo = registryAuthToken(registryUrl_.toString(), {recursive: true});
 

--- a/test.js
+++ b/test.js
@@ -213,3 +213,13 @@ test('does not omit specific deprecated versions', async t => {
 		deprecated: 'this package version has been deprecated as it was released by mistake',
 	});
 });
+
+test('handles defaults', async t => {
+	const json = await packageJson('querystring', {version: undefined, omitDeprecated: undefined});
+
+	t.like(json, {
+		name: 'querystring',
+		version: '0.2.1',
+		deprecated: 'The querystring API is considered Legacy. new code should use the URLSearchParams API instead.',
+	});
+});


### PR DESCRIPTION
Fixes #78.

Previously, setting `options.version` to `undefined` would return all versions of a package, instead of the latest version. This is technically a breaking change (especially for https://github.com/sindresorhus/package-json-cli), but I think it's the correct behavior.