### PR TITLE
Update mock server in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 	"devDependencies": {
 		"@types/node": "^20.11.5",
 		"ava": "^6.1.1",
-		"private-registry-mock": "^0.2.0",
-		"tsd": "^0.30.5",
+		"private-registry-mock": "^0.3.0",
+		"tsd": "^0.30.6",
 		"xo": "^0.57.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -144,7 +144,7 @@ test('private registry (bearer token)', async t => {
 		name: '@mockscope/foobar',
 	});
 
-	server.close();
+	await server.close();
 });
 
 test('private registry (basic token)', async t => {
@@ -164,7 +164,7 @@ test('private registry (basic token)', async t => {
 		name: '@mockscope2/foobar',
 	});
 
-	server.close();
+	await server.close();
 });
 
 test('omits deprecated versions by default', async t => {


### PR DESCRIPTION
I updated `private-registry-mock` (https://github.com/tommy-mitchell/private-registry-mock/releases/tag/v0.3.0) to gracefully shut down the server (and updated a dependency). Minor change, but may as well include it here too.