### PR TITLE
Throw if specified version is deprecated

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -243,6 +243,24 @@ export class PackageNotFoundError extends Error {
 	constructor(packageName: string);
 }
 
+/**
+The error thrown when the given package is deprecated.
+*/
+export class DeprecatedPackageError extends Error {
+	readonly name: 'DeprecatedPackageError';
+
+	constructor(packageName: string);
+}
+
+/**
+The error thrown when the given package version or range is deprecated.
+*/
+export class DeprecatedVersionError extends Error {
+	readonly name: 'DeprecatedVersionError';
+
+	constructor(packageName: string, version: string);
+}
+
 export type Options = Readonly<{
 	/**
 	Package version such as `1.0.0` or a [dist tag](https://docs.npmjs.com/cli/dist-tag) such as `latest`.
@@ -279,7 +297,7 @@ export type Options = Readonly<{
 	/**
 	Whether or not to omit deprecated versions of a package.
 
-	If set, versions marked as deprecated on the registry are omitted from results. Providing a dist tag or a specific version will still return that version, even if it's deprecated. If no version can be found once deprecated versions are omitted, a `VersionNotFoundError` is thrown.
+	If set, versions marked as deprecated on the registry are omitted from results. If all versions of a package are deprecated, a `DeprecatedPackageError` is thrown. If no version can be found once deprecated versions are omitted, a `DeprecatedVersionError` is thrown.
 
 	@default true
 	*/

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,6 +6,8 @@ import packageJson, {
 	type AbbreviatedVersion,
 	PackageNotFoundError,
 	VersionNotFoundError,
+	DeprecatedPackageError,
+	DeprecatedVersionError,
 } from './index.js';
 
 expectAssignable<Promise<AbbreviatedVersion>>(packageJson('package-json'));
@@ -49,3 +51,11 @@ expectType<PackageNotFoundError>(packageNotFoundError);
 const versionNotFoundError = new VersionNotFoundError('foo', 'bar');
 versionNotFoundError instanceof VersionNotFoundError; // eslint-disable-line @typescript-eslint/no-unused-expressions
 expectType<VersionNotFoundError>(versionNotFoundError);
+
+const deprecatedPackageError = new DeprecatedPackageError('foo');
+deprecatedPackageError instanceof DeprecatedPackageError; // eslint-disable-line @typescript-eslint/no-unused-expressions
+expectType<DeprecatedPackageError>(deprecatedPackageError);
+
+const deprecatedVersionError = new DeprecatedVersionError('foo', 'bar');
+deprecatedVersionError instanceof DeprecatedVersionError; // eslint-disable-line @typescript-eslint/no-unused-expressions
+expectType<DeprecatedVersionError>(deprecatedVersionError);

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ Default: `true`
 
 Whether or not to omit deprecated versions of a package.
 
-If set, versions marked as deprecated on the registry are omitted from results. Providing a dist tag or a specific version will still return that version, even if it's deprecated. If no version can be found once deprecated versions are omitted, a [`VersionNotFoundError`](#versionnotfounderror) is thrown.
+If set, versions marked as deprecated on the registry are omitted from results. If all versions of a package are deprecated, a [`DeprecatedPackageError`](#deprecatedpackageerror) is thrown. If no version can be found once deprecated versions are omitted, a [`DeprecatedVersionError`](#deprecatedversionerror) is thrown.
 
 ### PackageNotFoundError
 
@@ -85,6 +85,14 @@ The error thrown when the given package name cannot be found.
 ### VersionNotFoundError
 
 The error thrown when the given package version cannot be found.
+
+### DeprecatedPackageError
+
+The error thrown when the given package is deprecated.
+
+### DeprecatedVersionError
+
+The error thrown when the given package version or range is deprecated.
 
 ## Authentication
 


### PR DESCRIPTION
Ref: https://github.com/sindresorhus/latest-version-cli/pull/7#discussion_r1503745481

Changes:

- throws a `DeprecatedPackageError` if `omitDeprecated = true` and all versions are deprecated
- if a version/range can't be found after omitting deprecated versions, throws a `DeprecatedVersionError` if the version was omitted
- if a specific dist tag resolves to a deprecated version, throws a `DeprecatedVersionError`

---

The new logic to handle this is a bit complex, so I'll try to look back over it with fresh eyes later.